### PR TITLE
Mark Dobby as `raw` dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,12 @@
 {deps,
  [{lager, "2.1.1", {git, "https://github.com/basho/lager", {tag, "2.1.1"}}},
   {recon, ".*", {git, "https://github.com/ferd/recon.git", {branch, "master"}}},
-  {dobby, ".*", {git, "https://github.com/FlowForwarding/dobby.git", {branch, "master"}}},
-  {dobby_clib, ".*", {git, "https://github.com/FlowForwarding/dobby_clib.git", {branch, "master"}}}]
+  %% The [raw] option makes that the dobby is not treated as regular dependency
+  %% and retool doesn't complain
+  {dobby, ".*", {git, "https://github.com/FlowForwarding/dobby.git",
+                 {branch, "master"}, [raw]}},
+  {dobby_clib, ".*", {git, "https://github.com/FlowForwarding/dobby_clib.git",
+                      {branch, "master"}}}]
 }.
 
 {cover_enabled, true}.


### PR DESCRIPTION
It is used only in tests. Marking it as raw is helpful for applications
that use Lucet as a dependency and want to generate a release. It is because
Dobby is a release on its own.
